### PR TITLE
Disable imjournal module

### DIFF
--- a/centos8/Dockerfile
+++ b/centos8/Dockerfile
@@ -104,6 +104,8 @@ RUN dnf -y install opendmarc; \
 # rsyslog
 RUN dnf -y install rsyslog; \
     sed -i 's/\(SysSock\.Use\)="off"/\1="on"/' /etc/rsyslog.conf; \
+    sed -i 's/\(^module.*load.*imjournal.*\)/#\1/' /etc/rsyslog.conf; \
+    sed -i 's/\(.*StateFile.*imjournal.*\)/#\1/' /etc/rsyslog.conf; \
     dnf clean all;
 
 # supervisor


### PR DESCRIPTION
On the Centos 8 build, the `/var/log/messages` gets flooded every second with:
```
Jan  5 15:35:40 90830236b6d5 rsyslogd: imjournal: Journal indicates no msgs when positioned at head.  [v8.2102.0-5.el8 try https://www.rsyslog.com/e/0 ]
Jan  5 15:35:41 90830236b6d5 rsyslogd: imjournal: Journal indicates no msgs when positioned at head.  [v8.2102.0-5.el8 try https://www.rsyslog.com/e/0 ]
Jan  5 15:35:42 90830236b6d5 rsyslogd: imjournal: Journal indicates no msgs when positioned at head.  [v8.2102.0-5.el8 try https://www.rsyslog.com/e/0 ]
Jan  5 15:35:43 90830236b6d5 rsyslogd: imjournal: Journal indicates no msgs when positioned at head.  [v8.2102.0-5.el8 try https://www.rsyslog.com/e/0 ]
Jan  5 15:35:44 90830236b6d5 rsyslogd: imjournal: Journal indicates no msgs when positioned at head.  [v8.2102.0-5.el8 try https://www.rsyslog.com/e/0 ]
Jan  5 15:35:45 90830236b6d5 rsyslogd: imjournal: Journal indicates no msgs when positioned at head.  [v8.2102.0-5.el8 try https://www.rsyslog.com/e/0 ]
Jan  5 15:35:46 90830236b6d5 rsyslogd: imjournal: Journal indicates no msgs when positioned at head.  [v8.2102.0-5.el8 try https://www.rsyslog.com/e/0 ]
```

The solution is to disable the imjournal module. 

Note: this module is already disabled in the Dockerfile of the Centos 7 build.